### PR TITLE
Don't use proc in title patterns

### DIFF
--- a/lib/puppet/type/keystone_user_role.rb
+++ b/lib/puppet/type/keystone_user_role.rb
@@ -95,8 +95,11 @@ Puppet::Type.newtype(:keystone_user_role) do
         r[:ensure] == :present
     end
     rv = [self[:user_domain]]
-    rv << self[:project_domain] if parameter_set?(:project_domain)
-    rv << self[:domain]         if parameter_set?(:domain)
+    if parameter_set?(:domain)
+      rv << self[:domain]
+    else
+      rv << self[:project_domain]
+    end
     # Only used to display the deprecation warning.
     rv << default_domain.name   unless default_domain.nil?
     rv
@@ -113,7 +116,6 @@ Puppet::Type.newtype(:keystone_user_role) do
     domain = user
     user_domain = Regexp.new(/(?:[^:@]|:[^:@])+/)
     project = user_domain
-    unset = ->(_) { PuppetX::Keystone::CompositeNamevar::Unset }
     [
       [
         # fully qualified user with fully qualified project
@@ -127,14 +129,11 @@ Puppet::Type.newtype(:keystone_user_role) do
       ],
       # fully qualified user with domain
       [
-        /^(#{user})::(#{user_domain})@::(#{domain})($)/,
+        /^(#{user})::(#{user_domain})@::(#{domain})$/,
         [
           [:user],
           [:user_domain],
-          [:domain],
-          # Don't want to have project_domain set to default, while
-          # not used.
-          [:project_domain, unset]
+          [:domain]
         ]
       ],
       # fully qualified user with project
@@ -157,11 +156,10 @@ Puppet::Type.newtype(:keystone_user_role) do
       ],
       # user with domain
       [
-        /^(#{user})@::(#{domain})($)/,
+        /^(#{user})@::(#{domain})$/,
         [
           [:user],
-          [:domain],
-          [:project_domain, unset]
+          [:domain]
         ]
       ],
       # user with project

--- a/spec/unit/type/keystone_user_role_spec.rb
+++ b/spec/unit/type/keystone_user_role_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Type.type(:keystone_user_role) do
         :user           => user,
         :user_domain    => 'user_domain',
         :project        => PuppetX::Keystone::CompositeNamevar::Unset,
-        :project_domain => PuppetX::Keystone::CompositeNamevar::Unset,
+        :project_domain => 'Default',
         :domain         => 'domain'
     end
 
@@ -67,7 +67,7 @@ describe Puppet::Type.type(:keystone_user_role) do
         :user           => user,
         :user_domain    => 'Default',
         :project        => PuppetX::Keystone::CompositeNamevar::Unset,
-        :project_domain => PuppetX::Keystone::CompositeNamevar::Unset,
+        :project_domain => 'Default',
         :domain         => 'domain'
     end
 


### PR DESCRIPTION
Using a proc in type title patterns causes an error when generating puppet types for environment isolation. For example, running `puppet generate types` on a puppet master produces the following error:
```
Error: /etc/puppetlabs/code/environments/production/modules/keystone/lib/puppet/type/keystone_user_role.rb: title patterns that use procs are not supported.
```

This commit changes the `project_domain` parameter to always default to `DEFAULT_DOMAIN` even when using a `<user>::<user_domain>@::<domain>` or `<user>@::<domain>` title pattern. The only place I could find that utilized `project_domain` being unset was determining `keystone_domain` autorequires. The logic was updated to reflect that `project_domain` is either set or should use the default unless `domain` is set.